### PR TITLE
Fix the NullPointerException

### DIFF
--- a/run_gaussian_lda.sh
+++ b/run_gaussian_lda.sh
@@ -61,6 +61,7 @@ echo 'The output directory is' $DIR_NAME
 rm -rf bin/*
 
 #compile
+mkdir -p bin
 javac -sourcepath src/ -d bin/ -cp "external_libs/ejml-0.25.jar:external_libs/commons-logging-1.2/commons-logging-1.2.jar:external_libs/commons-math3-3.3/commons-math3-3.3.jar" src/sampler/GaussianLDA.java
 
 #run

--- a/src/sampler/GaussianLDA.java
+++ b/src/sampler/GaussianLDA.java
@@ -460,7 +460,7 @@ public class GaussianLDA {
 		CommonOps.rowsToVector(data, dataVectors);
 		System.out.println("Total number of vectors are "+data.numRows);
 		//Read corpus
-		String inputCorpusFile = args[5];
+		String inputCorpusFile = args[6];
 		corpus = Data.readCorpus(inputCorpusFile);
 		System.out.println("Corpus file read");
 		N = corpus.size();


### PR DESCRIPTION
I tried to run `run_gaussian_lda.sh` and got the error below.

```
$ sh run_gaussian_lda.sh -n 10 -c data/nips/corpus.train -i data/glove/50.txt -d 50 -k 10
The output directory is output/D50/I10/K10/GLDA/ 4月_13_2018_14.52.06/
Total number of vectors are 4805
java.io.FileNotFoundException: 4月_13_2018_14.52.06 (ディレクトリです)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at java.io.FileInputStream.<init>(FileInputStream.java:93)
        at data.Data.readCorpus(Data.java:93)
        at sampler.GaussianLDA.main(GaussianLDA.java:464)
Corpus file read
Exception in thread "main" java.lang.NullPointerException
        at sampler.GaussianLDA.main(GaussianLDA.java:466)
```

At a first glance, this problem caused by index-mismatching in `args`.
So I modified the indexing and send this PR.

Thanks!